### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "SVG-Loaders",
-  "version": "1.0.2",
   "homepage": "https://github.com/SamHerbert/SVG-Loaders",
   "description": "Loading icons and small animations built purely in SVG, no CSS or JS.",
   "license": "MIT",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property